### PR TITLE
Maciel

### DIFF
--- a/src/domain/usecases/UseCases.ts
+++ b/src/domain/usecases/UseCases.ts
@@ -7,6 +7,7 @@ import { UpdateConfigUseCaseImpl } from './config/update.usecase';
 import { ReportDepositAllUseCaseImpl } from './report/deposit-all.usecase';
 import { ReportDepositOneUseCaseImpl } from './report/deposit-one.usecase';
 import { ReportDepositPaginatedUseCaseImpl } from './report/deposit-paginated.usecase';
+import { DepositResendUseCaseImpl } from './report/deposit-resend.usecase';
 import { BlockUserUseCaseImpl } from './user/blocked/block.usecase';
 import { ListBlockedUserUseCaseImpl } from './user/blocked/list-all.usecase';
 import { ListAllUserCaseImpl } from './user/list-all.usecase';
@@ -34,6 +35,7 @@ export const UseCases = {
       paginated: new ReportDepositPaginatedUseCaseImpl(reportRepository),
       all: new ReportDepositAllUseCaseImpl(reportRepository),
       one: new ReportDepositOneUseCaseImpl(reportRepository),
+      resendOrder: new DepositResendUseCaseImpl(reportRepository),
     },
   },
 };

--- a/src/domain/usecases/report/deposit-resend.usecase.ts
+++ b/src/domain/usecases/report/deposit-resend.usecase.ts
@@ -1,0 +1,33 @@
+import {
+  ReportDepositResendReq,
+  ReportDepositResendRes,
+  ReportRepository,
+} from '@/data/repositories/report.repository';
+import { Result } from '@/utils/Result';
+import { UseCase } from '@/utils/UseCase';
+
+export type DepositResendUseCase = UseCase<
+  ReportDepositResendReq,
+  ReportDepositResendRes
+>;
+
+export class DepositResendUseCaseImpl implements DepositResendUseCase {
+  constructor(private repository: ReportRepository) {}
+
+  async execute(req: ReportDepositResendReq): ReportDepositResendRes {
+    const { result } = await this.repository.sendOrder(req);
+
+    if (result.type === 'ERROR') {
+      switch (result.error.code) {
+        case 'SERIALIZATION':
+          return Result.Error({ code: 'SERIALIZATION' });
+        case 'NOT_FOUND':
+          return Result.Error({ code: 'NOT_FOUND' });
+        default:
+          return Result.Error({ code: 'UNKNOWN_ERROR' });
+      }
+    }
+
+    return Result.Success(result.data);
+  }
+}

--- a/src/view/screens/report/DepositDetail.tsx
+++ b/src/view/screens/report/DepositDetail.tsx
@@ -2,6 +2,7 @@ import { ReportedDeposit } from '@/domain/entities/report.entity';
 import { UseCases } from '@/domain/usecases/UseCases';
 import { useAuth } from '@/hooks/useAuth';
 import { Permission } from '@/models/permissions';
+import { Button } from '@/view/components/Button';
 import { Container } from '@/view/components/Container';
 import { Error } from '@/view/components/Error';
 import { Loading } from '@/view/components/Loading';
@@ -27,6 +28,7 @@ import {
 import { useCallback, useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { toast } from 'sonner';
+import { useResendOrder } from './useResendOrder';
 const StatusBadge = ({ status }: { status: string }) => {
   const getStatusConfig = (status: string) => {
     const statusLower = status.toLowerCase();
@@ -209,6 +211,7 @@ export function DepositDetail() {
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
   const navigate = useNavigate();
+  const { resendOrder, isLoading } = useResendOrder();
 
   const fetchDeposit = useCallback(async () => {
     setLoading(true);
@@ -297,6 +300,17 @@ export function DepositDetail() {
       </Container>
     );
   }
+
+  const handleResendOrder = async () => {
+    const confirmed = window.confirm(
+      'ATENÇÃO: Você realmente deseja REENVIAR o pedido {' +
+        deposit.transactionId +
+        '}?',
+    );
+    if (confirmed) {
+      await resendOrder({ id: deposit.transactionId });
+    }
+  };
 
   return (
     <Container>
@@ -636,6 +650,11 @@ export function DepositDetail() {
                 </div>
               </motion.div>
             )}
+            <br />
+            <Button
+              label={isLoading ? 'Enviando...' : 'Reenviar pedido'}
+              onClick={handleResendOrder}
+            ></Button>
           </AnimatePresence>
         </motion.div>
       </AnimatePresence>

--- a/src/view/screens/report/useResendOrder.ts
+++ b/src/view/screens/report/useResendOrder.ts
@@ -1,0 +1,36 @@
+import {
+  ReportDepositResendReq,
+  ReportDepositResendRes,
+} from '@/data/repositories/report.repository';
+import { UseCases } from '@/domain/usecases/UseCases';
+import { useCallback, useState } from 'react';
+
+export function useResendOrder() {
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [data, setData] = useState<ReportDepositResendRes | null>(null);
+
+  const resendOrder = useCallback(
+    async (req: ReportDepositResendReq) => {
+      setIsLoading(true);
+      setError(null);
+      setData(null);
+
+      try {
+        await UseCases.report.deposit.resendOrder.execute(req);
+      } catch (err) {
+        setError('Erro ao reenviar pedido ' + err);
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [UseCases],
+  );
+
+  return {
+    resendOrder,
+    isLoading,
+    error,
+    data,
+  };
+}


### PR DESCRIPTION
## 📋 Descrição

Adiciona um botão nos detalhes do depósito com o propósito de reenviar o pedido, esse botão chama a API passando o oderId. Como essa é uma funcionalidade crítica, há uma confirmação do usuário antes de chamar a API.

---

## 🧪 Tipo de mudança

Marque as opções que se aplicam:

- [ ] Bugfix (correção de um problema)
- [X] Feature (nova funcionalidade)
- [ ] Refatoração (mudança de código sem adicionar nova funcionalidade ou corrigir bug)
- [ ] Documentação (adiciona ou melhora documentação)
- [ ] Testes (adiciona ou melhora cobertura de testes)
- [ ] Chore (mudança de configuração, dependências ou tarefas internas)

---

## ✅ Checklist

- [X] O código segue o padrão do projeto
- [X] Testes foram adicionados ou atualizados
- [X] A build está passando localmente
- [X] Documentação foi atualizada (quando necessário)
- [X] Nenhum arquivo sensível está sendo enviado (ex: `.env`, secrets)

---

## 🧾 Issue relacionada

Conecta-se à Issue Não se aplica

---

## 🖼️ Screenshots

![image](https://github.com/user-attachments/assets/ed580bd0-0eb0-4554-877c-fe9e534fa5a1)

Ao clicar no botão:

![image](https://github.com/user-attachments/assets/c873049d-7419-4ac3-a6a5-c924b32a1523)

---

## 🧠 Notas adicionais

O botão está funcionando (fazendo a request na API), mas é necessário fazer algumas modificações para melhorar a usabilidade, como mostrar quando ocorreu algum erro, e também melhorar o alerta de confirmação, por exemplo. Isso será adicionado num PR futuro.